### PR TITLE
Rename storefront data retrieval methods

### DIFF
--- a/managers/storefront_manager.py
+++ b/managers/storefront_manager.py
@@ -101,7 +101,7 @@ class StorefrontManager:
         return product
 
     @staticmethod
-    async def select_hole_storefront_data(db: AsyncSession) -> StorefrontData:
+    async def select_whole_storefront_data(db: AsyncSession) -> StorefrontData:
         query = text(
             """
             SELECT

--- a/routers/storefront_router.py
+++ b/routers/storefront_router.py
@@ -15,8 +15,8 @@ router = APIRouter(prefix="/storefront")
 
 
 @router.get("/all", response_model=StorefrontData)
-async def get_hole_storefront(db: AsyncSession = Depends(get_db)):
-    data = await StorefrontManager.select_hole_storefront_data(db)
+async def get_whole_storefront(db: AsyncSession = Depends(get_db)):
+    data = await StorefrontManager.select_whole_storefront_data(db)
     return data
 
 


### PR DESCRIPTION
## Summary
- rename router handler `get_whole_storefront`
- rename manager method `select_whole_storefront_data`

## Testing
- `pytest`
- `ruff check routers/storefront_router.py managers/storefront_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_6898516028548320a48a107c3a5a4d7e