### PR TITLE
Fix cart status path parameter

### DIFF
--- a/routers/cart_router.py
+++ b/routers/cart_router.py
@@ -153,7 +153,7 @@ async def patch_cart_line_item_quantity(
     return response_data
 
 
-@router.patch("/{status}", response_model=Cart)
+@router.patch("/{cart_status}", response_model=Cart)
 async def patch_cart_status(
     cart_status: CartStatusEnum,
     user_id: str = Depends(get_current_user_id),


### PR DESCRIPTION
## Summary
- ensure cart status route uses matching parameter name

## Testing
- `ruff check routers/cart_router.py`
- `uv run python test_cart_status_endpoint.py` *(stubbed)*

------
https://chatgpt.com/codex/tasks/task_e_6898518d38588320b5a0767287670a15