### PR TITLE
Add claim and refund handling

### DIFF
--- a/managers/claim_manager.py
+++ b/managers/claim_manager.py
@@ -1,0 +1,63 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from schemas.claim_data_schemas import ClaimDataReq, ClaimDataRes
+from schemas.claim_schemas import Claim, ClaimStatusEnum
+from schemas.claim_item_schemas import ClaimItem
+from models.claim_model import ClaimModel
+from models.claim_item_model import ClaimItemModel
+
+
+class ClaimManager:
+    @staticmethod
+    async def create_claim(
+        data: ClaimDataReq, user_id: str, db: AsyncSession
+    ) -> ClaimDataRes:
+        claim_row = ClaimModel(**data.claim_request.model_dump(), user_id=user_id)
+        db.add(claim_row)
+        await db.commit()
+        claim_items_rows = [
+            ClaimItemModel(**item.model_dump(), claim_id=claim_row.id)
+            for item in data.items
+        ]
+        db.add_all(claim_items_rows)
+        await db.commit()
+
+        claim_items = [ClaimItem.model_validate(item) for item in claim_items_rows]
+        claim = Claim.model_validate(claim_row)
+
+        return ClaimDataRes(claim_request=claim, items=claim_items)
+
+    @staticmethod
+    async def select_user_claims(user_id: str, db: AsyncSession) -> list[ClaimDataRes]:
+        result = await db.execute(
+            select(ClaimModel)
+                .where(ClaimModel.user_id == user_id)
+                .options(selectinload(ClaimModel.items))
+        )
+        claim_rows = result.scalars().all()
+
+        return [
+            ClaimDataRes(
+                claim_request=Claim.model_validate(claim_row),
+                items=[ClaimItem.model_validate(item) for item in claim_row.items],
+            )
+            for claim_row in claim_rows
+        ]
+
+    @staticmethod
+    async def update_claim_status(
+        claim_id: str, status: ClaimStatusEnum, db: AsyncSession
+    ) -> Claim:
+        result = await db.execute(select(ClaimModel).where(ClaimModel.id == claim_id))
+        claim = result.scalars().first()
+
+        if not claim:
+            raise ValueError("Claim not found")
+
+        claim.status = status  # type: ignore[reportAttributeAccessIssue]
+        await db.commit()
+        await db.refresh(claim)
+
+        return Claim.model_validate(claim)

--- a/managers/refund_manager.py
+++ b/managers/refund_manager.py
@@ -1,0 +1,48 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from sqlalchemy.exc import NoResultFound
+
+from schemas.refund_schemas import (
+    RefundCreate,
+    Refund,
+    RefundStatusEnum,
+)
+from models.refund_model import RefundModel
+
+
+class RefundManager:
+    @staticmethod
+    async def create_refund(
+        data: RefundCreate, user_id: str, db: AsyncSession
+    ) -> Refund:
+        refund_row = RefundModel(**data.model_dump(), user_id=user_id)
+        db.add(refund_row)
+        await db.commit()
+        await db.refresh(refund_row)
+
+        return Refund.model_validate(refund_row)
+
+    @staticmethod
+    async def select_user_refunds(user_id: str, db: AsyncSession) -> list[Refund]:
+        result = await db.execute(
+            select(RefundModel).where(RefundModel.user_id == user_id)
+        )
+        refund_rows = result.scalars().all()
+
+        return [Refund.model_validate(row) for row in refund_rows]
+
+    @staticmethod
+    async def update_refund_status(
+        refund_id: str, status: RefundStatusEnum, db: AsyncSession
+    ) -> Refund:
+        result = await db.execute(select(RefundModel).where(RefundModel.id == refund_id))
+        refund = result.scalars().first()
+
+        if not refund:
+            raise NoResultFound
+
+        refund.status = status  # type: ignore[reportAttributeAccessIssue]
+        await db.commit()
+        await db.refresh(refund)
+
+        return Refund.model_validate(refund)

--- a/migrations/0008_add_claim_and_refund_tables.sql
+++ b/migrations/0008_add_claim_and_refund_tables.sql
@@ -1,0 +1,38 @@
+-- Create claims table
+CREATE TABLE claims (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    order_id UUID NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL,
+
+    status VARCHAR(30) NOT NULL DEFAULT 'pending',
+    reason VARCHAR(255),
+
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create claim_items table
+CREATE TABLE claim_items (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    claim_id UUID NOT NULL REFERENCES claims(id) ON DELETE CASCADE,
+    order_item_id UUID NOT NULL REFERENCES order_items(id) ON DELETE CASCADE,
+
+    quantity INTEGER NOT NULL,
+    resolution VARCHAR(30),
+    refund_amount NUMERIC(10, 2)
+);
+
+-- Create refunds table
+CREATE TABLE refunds (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    claim_id UUID REFERENCES claims(id) ON DELETE SET NULL,
+    order_id UUID NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL,
+    amount NUMERIC(10, 2) NOT NULL,
+
+    status VARCHAR(30) NOT NULL DEFAULT 'pending',
+    reason VARCHAR(255),
+
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/models/claim_item_model.py
+++ b/models/claim_item_model.py
@@ -1,0 +1,27 @@
+from uuid import uuid4
+
+from sqlalchemy import Column, UUID, Integer, String, Numeric, ForeignKey
+from sqlalchemy.orm import relationship
+
+from db import Base
+
+
+class ClaimItemModel(Base):
+    __tablename__ = "claim_items"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+
+    claim_id = Column(
+        UUID(as_uuid=True), ForeignKey("claims.id", ondelete="CASCADE"), nullable=False
+    )
+    order_item_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("order_items.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    quantity = Column(Integer, nullable=False)
+    resolution = Column(String(30), nullable=True)
+    refund_amount = Column(Numeric(10, 2), nullable=True)
+
+    claim = relationship("ClaimModel", back_populates="items")

--- a/models/claim_model.py
+++ b/models/claim_model.py
@@ -1,0 +1,30 @@
+from uuid import uuid4
+
+from sqlalchemy import Column, UUID, String, ForeignKey, TIMESTAMP, func
+from sqlalchemy.orm import relationship
+
+from db import Base
+
+
+class ClaimModel(Base):
+    __tablename__ = "claims"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+
+    order_id = Column(
+        UUID(as_uuid=True), ForeignKey("orders.id", ondelete="CASCADE"), nullable=False
+    )
+    user_id = Column(UUID(as_uuid=True), nullable=False)
+
+    status = Column(String(30), nullable=False, default="pending")
+    reason = Column(String(255), nullable=True)
+
+    created_at = Column(TIMESTAMP, server_default=func.now())
+    updated_at = Column(TIMESTAMP, server_default=func.now(), onupdate=func.now())
+
+    items = relationship(
+        "ClaimItemModel", back_populates="claim", cascade="all, delete-orphan"
+    )
+    refunds = relationship(
+        "RefundModel", back_populates="claim", cascade="all, delete-orphan"
+    )

--- a/models/refund_model.py
+++ b/models/refund_model.py
@@ -1,0 +1,27 @@
+from uuid import uuid4
+
+from sqlalchemy import Column, UUID, String, ForeignKey, Numeric, TIMESTAMP, func
+from sqlalchemy.orm import relationship
+
+from db import Base
+
+
+class RefundModel(Base):
+    __tablename__ = "refunds"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+
+    claim_id = Column(UUID(as_uuid=True), ForeignKey("claims.id", ondelete="SET NULL"))
+    order_id = Column(
+        UUID(as_uuid=True), ForeignKey("orders.id", ondelete="CASCADE"), nullable=False
+    )
+    user_id = Column(UUID(as_uuid=True), nullable=False)
+
+    amount = Column(Numeric(10, 2), nullable=False)
+    status = Column(String(30), nullable=False, default="pending")
+    reason = Column(String(255), nullable=True)
+
+    created_at = Column(TIMESTAMP, server_default=func.now())
+    updated_at = Column(TIMESTAMP, server_default=func.now(), onupdate=func.now())
+
+    claim = relationship("ClaimModel", back_populates="refunds")

--- a/routers/claim_router.py
+++ b/routers/claim_router.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+from db import get_db
+from auth.token import get_current_user_id
+from schemas.claim_data_schemas import ClaimDataReq, ClaimDataRes
+from schemas.claim_schemas import Claim, ClaimStatusUpdate
+from managers.claim_manager import ClaimManager
+
+
+router = APIRouter(prefix="/claims", tags=["claims"])
+
+
+@router.post("/", status_code=status.HTTP_201_CREATED, response_model=ClaimDataRes)
+async def post_claim(
+    data: ClaimDataReq,
+    user_id: str = Depends(get_current_user_id),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a new claim."""
+    return await ClaimManager.create_claim(data, user_id, db)
+
+
+@router.get("/", response_model=list[ClaimDataRes])
+async def get_user_claims(
+    user_id: str = Depends(get_current_user_id), db: AsyncSession = Depends(get_db)
+):
+    return await ClaimManager.select_user_claims(user_id, db)
+
+
+@router.patch("/{claim_id}", response_model=Claim)
+async def patch_claim_status(
+    claim_id: str,
+    status_update: ClaimStatusUpdate,
+    user_id: str = Depends(get_current_user_id),
+    db: AsyncSession = Depends(get_db),
+):
+    return await ClaimManager.update_claim_status(claim_id, status_update.status, db)
+

--- a/routers/main_router.py
+++ b/routers/main_router.py
@@ -11,6 +11,8 @@ from routers import (
     cart_router,
     order_router,
     return_router,
+    claim_router,
+    refund_router,
     image_router,
     review_router,
     email_router,
@@ -28,6 +30,8 @@ main_router.include_router(auth_router.router)
 main_router.include_router(cart_router.router)
 main_router.include_router(order_router.router)
 main_router.include_router(return_router.router)
+main_router.include_router(claim_router.router)
+main_router.include_router(refund_router.router)
 main_router.include_router(image_router.router)
 main_router.include_router(review_router.router)
 main_router.include_router(email_router.router)

--- a/routers/refund_router.py
+++ b/routers/refund_router.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.exc import NoResultFound
+
+
+from db import get_db
+from auth.token import get_current_user_id
+from schemas.refund_schemas import RefundCreate, Refund, RefundStatusUpdate
+from managers.refund_manager import RefundManager
+
+
+router = APIRouter(prefix="/refunds", tags=["refunds"])
+
+
+@router.post("/", status_code=status.HTTP_201_CREATED, response_model=Refund)
+async def post_refund(
+    data: RefundCreate,
+    user_id: str = Depends(get_current_user_id),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a new refund."""
+    return await RefundManager.create_refund(data, user_id, db)
+
+
+@router.get("/", response_model=list[Refund])
+async def get_user_refunds(
+    user_id: str = Depends(get_current_user_id), db: AsyncSession = Depends(get_db)
+):
+    return await RefundManager.select_user_refunds(user_id, db)
+
+
+@router.patch("/{refund_id}", response_model=Refund)
+async def patch_refund_status(
+    refund_id: str,
+    status_update: RefundStatusUpdate,
+    user_id: str = Depends(get_current_user_id),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        return await RefundManager.update_refund_status(
+            refund_id, status_update.status, db
+        )
+    except NoResultFound:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Refund not found")
+

--- a/schemas/claim_data_schemas.py
+++ b/schemas/claim_data_schemas.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+
+from schemas.claim_schemas import ClaimCreate, Claim
+from schemas.claim_item_schemas import ClaimItemCreate, ClaimItem
+
+
+class ClaimDataReq(BaseModel):
+    claim_request: ClaimCreate
+    items: list[ClaimItemCreate]
+
+
+class ClaimDataRes(BaseModel):
+    claim_request: Claim
+    items: list[ClaimItem]

--- a/schemas/claim_item_schemas.py
+++ b/schemas/claim_item_schemas.py
@@ -1,0 +1,34 @@
+from decimal import Decimal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, field_serializer
+
+
+class ClaimItemBase(BaseModel):
+    quantity: int
+    resolution: str | None = None
+    refund_amount: Decimal | None = None
+
+
+class ClaimItemCreate(ClaimItemBase):
+    order_item_id: str
+
+
+class ClaimItem(ClaimItemBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    claim_id: UUID
+    order_item_id: UUID
+
+    @field_serializer("id")
+    def serialize_id(self, id: UUID, _info):
+        return str(id)
+
+    @field_serializer("claim_id")
+    def serialize_claim_id(self, claim_id: UUID, _info):
+        return str(claim_id)
+
+    @field_serializer("order_item_id")
+    def serialize_order_item_id(self, order_item_id: UUID, _info):
+        return str(order_item_id)

--- a/schemas/claim_schemas.py
+++ b/schemas/claim_schemas.py
@@ -1,0 +1,46 @@
+from uuid import UUID
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, field_serializer
+
+
+class ClaimStatusEnum(StrEnum):
+    PENDING = "pending"
+    REJECTED = "rejected"
+    APPROVED_REFUND_PARTIAL = "approved_refund_partial"
+    APPROVED_REFUND_FULL = "approved_refund_full"
+    APPROVED_RETURN = "approved_return"
+    APPROVED_REFUND_RETURN = "approved_refund_return"
+
+
+class ClaimBase(BaseModel):
+    status: ClaimStatusEnum = ClaimStatusEnum.PENDING
+    reason: str | None = None
+
+
+class ClaimCreate(ClaimBase):
+    order_id: str
+
+
+class ClaimStatusUpdate(BaseModel):
+    status: ClaimStatusEnum
+
+
+class Claim(ClaimBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    user_id: UUID
+    order_id: UUID
+
+    @field_serializer("id")
+    def serialize_id(self, id: UUID, _info):
+        return str(id)
+
+    @field_serializer("user_id")
+    def serialize_user_id(self, user_id: UUID, _info):
+        return str(user_id)
+
+    @field_serializer("order_id")
+    def serialize_order_id(self, order_id: UUID, _info):
+        return str(order_id)

--- a/schemas/refund_schemas.py
+++ b/schemas/refund_schemas.py
@@ -1,0 +1,51 @@
+from decimal import Decimal
+from enum import StrEnum
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, field_serializer
+
+
+class RefundStatusEnum(StrEnum):
+    PENDING = "pending"
+    COMPLETED = "completed"
+    REJECTED = "rejected"
+
+
+class RefundBase(BaseModel):
+    amount: Decimal
+    status: RefundStatusEnum = RefundStatusEnum.PENDING
+    reason: str | None = None
+
+
+class RefundCreate(RefundBase):
+    order_id: str
+    claim_id: str | None = None
+
+
+class RefundStatusUpdate(BaseModel):
+    status: RefundStatusEnum
+
+
+class Refund(RefundBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    user_id: UUID
+    order_id: UUID
+    claim_id: UUID | None = None
+
+    @field_serializer("id")
+    def serialize_id(self, id: UUID, _info):
+        return str(id)
+
+    @field_serializer("user_id")
+    def serialize_user_id(self, user_id: UUID, _info):
+        return str(user_id)
+
+    @field_serializer("order_id")
+    def serialize_order_id(self, order_id: UUID, _info):
+        return str(order_id)
+
+    @field_serializer("claim_id")
+    def serialize_claim_id(self, claim_id: UUID | None, _info):
+        return str(claim_id) if claim_id else None


### PR DESCRIPTION
## Summary
- add migrations for claims and refunds
- implement claim/refund models, schemas, managers, and routers
- expose new claim and refund routes in main router
- raise `NoResultFound` for missing refunds and return HTTP 404

## Testing
- `ruff check managers/refund_manager.py routers/refund_router.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689857bdc9308320a9f1de1df2b30bdb