### PR TITLE
Add user review listing with order item images

### DIFF
--- a/schemas/user_review_schemas.py
+++ b/schemas/user_review_schemas.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+
+from schemas.review_schemas import Review
+from schemas.order_items_schemas import OrderItem
+
+
+class OrderItemWithImage(OrderItem):
+    """Order item data with an optional signed image URL."""
+    image_url: str | None = None
+
+
+class UserReviewResponse(BaseModel):
+    """Response model containing a review and its related order item."""
+    review: Review
+    order_item: OrderItemWithImage


### PR DESCRIPTION
## Summary
- add `/reviews/user-reviews` endpoint to list authenticated user's reviews
- include associated order item details with signed image URLs
- support retrieval in `ReviewManager` and new response schemas

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68998093ce48832096ac46bb7f5314ca