### PR TITLE
feat: add wishlist api

### DIFF
--- a/managers/wishlist_manager.py
+++ b/managers/wishlist_manager.py
@@ -1,0 +1,56 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, delete
+
+from schemas.wishlist_item_schemas import WishlistItemCreate, WishlistItem
+from models.wishlist_item_model import WishlistItemModel
+from models.product_variant_model import ProductVariantModel
+
+
+class WishlistManager:
+    @staticmethod
+    async def insert_wishlist_item(
+        item_data: WishlistItemCreate, db: AsyncSession
+    ) -> WishlistItem:
+        """Insert a new wishlist item into the database."""
+        image_name = await db.execute(
+            select(ProductVariantModel.image_name).where(
+                ProductVariantModel.id == item_data.product_variant_id
+            )
+        )
+        image_name = image_name.scalars().first()
+
+        new_item = WishlistItemModel(**item_data.model_dump(), image_name=image_name)
+        db.add(new_item)
+        await db.commit()
+        await db.refresh(new_item)
+        return WishlistItem.model_validate(new_item)
+
+    @staticmethod
+    async def select_wishlist_items(
+        user_id: str, db: AsyncSession
+    ) -> list[WishlistItem]:
+        """Retrieve all wishlist items for a specific user."""
+        result = await db.execute(
+            select(WishlistItemModel).where(WishlistItemModel.user_id == user_id)
+        )
+        items = result.scalars().all()
+        return [WishlistItem.model_validate(item) for item in items]
+
+    @staticmethod
+    async def delete_wishlist_item(item_id: str, db: AsyncSession) -> None:
+        """Delete a wishlist item by its ID."""
+        await db.execute(
+            delete(WishlistItemModel).where(WishlistItemModel.id == item_id)
+        )
+        await db.commit()
+
+    @staticmethod
+    async def select_wishlist_item_by_id(
+        item_id: str, db: AsyncSession
+    ) -> WishlistItem | None:
+        """Retrieve a specific wishlist item by its ID."""
+        result = await db.execute(
+            select(WishlistItemModel).where(WishlistItemModel.id == item_id)
+        )
+        item = result.scalars().first()
+        return WishlistItem.model_validate(item) if item else None

--- a/migrations/0009_add_wishlist_tables.sql
+++ b/migrations/0009_add_wishlist_tables.sql
@@ -1,0 +1,11 @@
+-- Create the wishlist_items table
+CREATE TABLE wishlist_items (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL,
+    product_variant_id UUID NOT NULL,
+    price NUMERIC(10, 2) NOT NULL,
+    image_name VARCHAR(255),
+    name VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP DEFAULT NOW(),
+    updated_at TIMESTAMP DEFAULT NOW()
+);

--- a/models/wishlist_item_model.py
+++ b/models/wishlist_item_model.py
@@ -1,0 +1,19 @@
+from uuid import uuid4
+
+from sqlalchemy import Column, UUID, String, TIMESTAMP, Numeric, func
+
+from db import Base
+
+
+class WishlistItemModel(Base):
+    __tablename__ = "wishlist_items"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    user_id = Column(UUID(as_uuid=True), nullable=False)
+    product_variant_id = Column(UUID(as_uuid=True), nullable=False)
+    price = Column(Numeric(10, 2), nullable=False)
+    image_name = Column(String(255))
+    name = Column(String(100), nullable=False)
+
+    created_at = Column(TIMESTAMP, server_default=func.now())
+    updated_at = Column(TIMESTAMP, server_default=func.now(), onupdate=func.now())

--- a/routers/main_router.py
+++ b/routers/main_router.py
@@ -9,6 +9,7 @@ from routers import (
     storefront_router,
     auth_router,
     cart_router,
+    wishlist_router,
     order_router,
     return_router,
     claim_router,
@@ -28,6 +29,7 @@ main_router.include_router(product_variants.router)
 main_router.include_router(storefront_router.router)
 main_router.include_router(auth_router.router)
 main_router.include_router(cart_router.router)
+main_router.include_router(wishlist_router.router)
 main_router.include_router(order_router.router)
 main_router.include_router(return_router.router)
 main_router.include_router(claim_router.router)

--- a/routers/wishlist_router.py
+++ b/routers/wishlist_router.py
@@ -1,0 +1,79 @@
+from fastapi import APIRouter, status, Depends, HTTPException
+
+from db import get_db
+from auth.token import get_current_user_id
+from storage.gcp_storage import generate_signed_url
+from schemas.wishlist_item_schemas import (
+    WishlistItemCreate,
+    WishlistItemReq,
+    WishlistItemResp,
+)
+from managers.wishlist_manager import WishlistManager
+
+
+router = APIRouter(prefix="/wishlist", tags=["wishlist"])
+
+
+@router.post("/", response_model=WishlistItemResp, status_code=status.HTTP_201_CREATED)
+async def post_wishlist_item(
+    item_req: WishlistItemReq,
+    user_id: str = Depends(get_current_user_id),
+    db=Depends(get_db),
+):
+    """Add a new item to the user's wishlist."""
+    item_data = WishlistItemCreate(
+        product_variant_id=item_req.product_variant_id,
+        price=item_req.price,
+        name=item_req.name,
+        user_id=user_id,
+    )
+
+    wishlist_item = await WishlistManager.insert_wishlist_item(item_data, db)
+    image_url = generate_signed_url(wishlist_item.image_name)
+    response_data = WishlistItemResp(
+        id=wishlist_item.id,
+        user_id=wishlist_item.user_id,
+        product_variant_id=wishlist_item.product_variant_id,
+        price=wishlist_item.price,
+        name=wishlist_item.name,
+        image_url=image_url,
+    )
+    return response_data
+
+
+@router.get("/", response_model=list[WishlistItemResp])
+async def get_user_wishlist(
+    user_id: str = Depends(get_current_user_id), db=Depends(get_db)
+):
+    """Retrieve all wishlist items for the user."""
+    items = await WishlistManager.select_wishlist_items(user_id, db)
+    response_items = []
+    for item in items:
+        image_url = generate_signed_url(item.image_name)
+        response_items.append(
+            WishlistItemResp(
+                id=item.id,
+                user_id=item.user_id,
+                product_variant_id=item.product_variant_id,
+                price=item.price,
+                name=item.name,
+                image_url=image_url,
+            )
+        )
+    return response_items
+
+
+@router.delete("/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_wishlist_item(
+    item_id: str, user_id: str = Depends(get_current_user_id), db=Depends(get_db)
+):
+    """Delete a wishlist item by its ID."""
+    existing_item = await WishlistManager.select_wishlist_item_by_id(item_id, db)
+    if not existing_item or existing_item.user_id != user_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Item not found or does not belong to the user",
+        )
+
+    await WishlistManager.delete_wishlist_item(item_id, db)
+    return {"message": "Wishlist item deleted successfully"}

--- a/schemas/wishlist_item_schemas.py
+++ b/schemas/wishlist_item_schemas.py
@@ -1,0 +1,46 @@
+from uuid import UUID
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, field_serializer
+
+
+class WishlistItemBase(BaseModel):
+    price: float
+    name: str
+
+
+class WishlistItemReq(WishlistItemBase):
+    product_variant_id: str
+
+
+class WishlistItemCreate(WishlistItemBase):
+    product_variant_id: str
+    user_id: str
+
+
+class WishlistItemConfig(WishlistItemBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    user_id: UUID
+    product_variant_id: UUID
+
+    @field_serializer("id")
+    def serialize_id(self, id: UUID, _info):
+        return str(id)
+
+    @field_serializer("user_id")
+    def serialize_user_id(self, user_id: UUID, _info):
+        return str(user_id)
+
+    @field_serializer("product_variant_id")
+    def serialize_product_variant_id(self, product_variant_id: UUID, _info):
+        return str(product_variant_id)
+
+
+class WishlistItem(WishlistItemConfig):
+    image_name: Optional[str] = None
+
+
+class WishlistItemResp(WishlistItemConfig):
+    image_url: Optional[str] = None


### PR DESCRIPTION
## Summary
- allow users to manage wishlist items and attach product variants
- expose wishlist routes from the main API router
- add migration and models for wishlist storage

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68998950fd1c8320ba5ec3e1a224898b